### PR TITLE
🧹 Remove unused LogLevel export

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -101,5 +101,5 @@ try {
   );
 }
 
-export { config, env, LogLevel, NodeEnv };
+export { config, env, NodeEnv };
 export type { Config, Env };


### PR DESCRIPTION
🎯 **What:** Removed `LogLevel` from the exports list in `src/config.ts`.
💡 **Why:** `LogLevel` is an internal enum used only within `src/config.ts`. Exporting it unnecessarily pollutes the public API of the module. Removing it improves encapsulation and code readability.
✅ **Verification:** Verified via grep that `LogLevel` is not imported or used anywhere else in the codebase. Ran the full test suite, type checker, and linter to confirm no regressions.
✨ **Result:** A cleaner and more strictly encapsulated `config` module.

---
*PR created automatically by Jules for task [1279813493093819263](https://jules.google.com/task/1279813493093819263) started by @jrobinsonc*