### PR TITLE
🧪 Add tests for getProxyUri utility function

### DIFF
--- a/tests/utils/get-proxy-uri.test.ts
+++ b/tests/utils/get-proxy-uri.test.ts
@@ -3,33 +3,37 @@ import type { FastifyInstance } from 'fastify';
 
 describe('getProxyUri', () => {
   it('should return host and port when address returns AddressInfo', () => {
-    const fastifyMock = {
+    const fastifyMock: FastifyInstance = {
       server: {
         address: () => ({ address: '127.0.0.1', port: 3000, family: 'IPv4' }),
       },
     } as unknown as FastifyInstance;
 
-    const uri = getProxyUri(fastifyMock);
+    const uri: string = getProxyUri(fastifyMock);
     expect(uri).toBe('127.0.0.1:3000');
   });
 
   it('should throw an error when address returns null', () => {
-    const fastifyMock = {
+    const fastifyMock: FastifyInstance = {
       server: {
         address: () => null,
       },
     } as unknown as FastifyInstance;
 
-    expect(() => getProxyUri(fastifyMock)).toThrow('Unable to determine server address');
+    expect(() => getProxyUri(fastifyMock)).toThrow(
+      'Unable to determine server address',
+    );
   });
 
   it('should throw an error when address returns a string', () => {
-    const fastifyMock = {
+    const fastifyMock: FastifyInstance = {
       server: {
         address: () => '/path/to/socket',
       },
     } as unknown as FastifyInstance;
 
-    expect(() => getProxyUri(fastifyMock)).toThrow('Unable to determine server address');
+    expect(() => getProxyUri(fastifyMock)).toThrow(
+      'Unable to determine server address',
+    );
   });
 });

--- a/tests/utils/get-proxy-uri.test.ts
+++ b/tests/utils/get-proxy-uri.test.ts
@@ -1,0 +1,35 @@
+import { getProxyUri } from '../../src/utils/get-proxy-uri';
+import type { FastifyInstance } from 'fastify';
+
+describe('getProxyUri', () => {
+  it('should return host and port when address returns AddressInfo', () => {
+    const fastifyMock = {
+      server: {
+        address: () => ({ address: '127.0.0.1', port: 3000, family: 'IPv4' }),
+      },
+    } as unknown as FastifyInstance;
+
+    const uri = getProxyUri(fastifyMock);
+    expect(uri).toBe('127.0.0.1:3000');
+  });
+
+  it('should throw an error when address returns null', () => {
+    const fastifyMock = {
+      server: {
+        address: () => null,
+      },
+    } as unknown as FastifyInstance;
+
+    expect(() => getProxyUri(fastifyMock)).toThrow('Unable to determine server address');
+  });
+
+  it('should throw an error when address returns a string', () => {
+    const fastifyMock = {
+      server: {
+        address: () => '/path/to/socket',
+      },
+    } as unknown as FastifyInstance;
+
+    expect(() => getProxyUri(fastifyMock)).toThrow('Unable to determine server address');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR adds a missing test file for the `src/utils/get-proxy-uri.ts` utility function. The function is critical for determining the proxy URI from the Fastify server's address, but it lacked dedicated unit tests.

📊 **Coverage:** What scenarios are now tested
- The happy path, where `server.address()` returns an `AddressInfo` object, which is properly formatted into a `"host:port"` string.
- Error path where `server.address()` returns `null`, throwing an appropriate error.
- Error path where `server.address()` returns a `string` (e.g., unix socket), also throwing the same error.

✨ **Result:** The improvement in test coverage
The utility function is now fully covered by tests, improving the overall reliability of the codebase and ensuring regressions are caught if the logic changes in the future. All tests in the suite pass successfully.

---
*PR created automatically by Jules for task [16677742697528681393](https://jules.google.com/task/16677742697528681393) started by @jrobinsonc*