### PR TITLE
🔒 Fix Application Version Exposure in HTTP Headers

### DIFF
--- a/src/plugins/add-app-headers.ts
+++ b/src/plugins/add-app-headers.ts
@@ -5,7 +5,6 @@ import type {
   FastifyReply,
   FastifyRequest,
 } from 'fastify';
-import pkg from '../../package.json';
 import fp from 'fastify-plugin';
 
 /**
@@ -21,7 +20,7 @@ function addAppHeaders(
   done: FastifyPluginDoneFn,
 ): void {
   fastify.addHook('onSend', async (_: FastifyRequest, reply: FastifyReply) => {
-    reply.header('X-ProxyMate', pkg.version);
+    reply.header('X-ProxyMate', '1');
   });
 
   done();

--- a/tests/plugins/add-app-headers.test.ts
+++ b/tests/plugins/add-app-headers.test.ts
@@ -1,5 +1,4 @@
 import type { FastifyInstance, LightMyRequestResponse } from 'fastify';
-import pkg from '../../package.json';
 import { buildFastifyInstance } from '../__helpers__/fastify';
 import addAppHeaders from '../../src/plugins/add-app-headers';
 
@@ -12,6 +11,6 @@ describe('Add App Headers Plugin', () => {
       url: '/',
     });
 
-    expect(res.headers['x-proxymate']).toEqual(pkg.version);
+    expect(res.headers['x-proxymate']).toEqual('1');
   });
 });


### PR DESCRIPTION
🎯 **What:** The application version was being exposed in the `X-ProxyMate` HTTP header.
⚠️ **Risk:** Exposing the exact version of the application can help attackers identify known vulnerabilities in that specific version.
🛡️ **Solution:** Replaced `pkg.version` with a static value `'1'` in the header and removed the unused `package.json` import in both the plugin and its tests.

---
*PR created automatically by Jules for task [5771280637620263094](https://jules.google.com/task/5771280637620263094) started by @jrobinsonc*