### PR TITLE
🧹 Code health: Remove unused NodeEnv export

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -101,5 +101,5 @@ try {
   );
 }
 
-export { config, env, LogLevel, NodeEnv };
+export { config, env, LogLevel };
 export type { Config, Env };


### PR DESCRIPTION
🎯 **What:** Removed the unused `NodeEnv` enum from the export list in `src/config.ts`.
💡 **Why:** `NodeEnv` is only used internally within `src/config.ts`. Exporting it is unnecessary and removing it reduces the API surface area, improving code health and maintainability.
✅ **Verification:** Verified that `NodeEnv` is not referenced outside of `src/config.ts` via grepping. Ran the test suite (`pnpm test`), type checker (`pnpm check-types`), and linter (`pnpm lint`) to ensure no regressions were introduced.
✨ **Result:** Cleaned up dead code by removing an unused export without changing behavior.

---
*PR created automatically by Jules for task [12772907291932882587](https://jules.google.com/task/12772907291932882587) started by @jrobinsonc*