### PR TITLE
🧪 test(config): improve test coverage for config parsing

### DIFF
--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+
+describe('config.ts error paths', () => {
+  let readFileSyncSpy: jest.SpyInstance;
+  const originalEnv: NodeJS.ProcessEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    readFileSyncSpy = jest.spyOn(fs, 'readFileSync');
+  });
+
+  afterEach(() => {
+    readFileSyncSpy.mockRestore();
+    process.env = originalEnv;
+  });
+
+  describe('configuration file parsing', () => {
+    it('should throw TypeError on SyntaxError (invalid JSON)', async () => {
+      readFileSyncSpy.mockReturnValue('invalid json');
+      await expect(import('../src/config')).rejects.toThrow(TypeError);
+      await expect(import('../src/config')).rejects.toThrow(
+        'Failed to parse configuration file',
+      );
+    });
+
+    it('should throw TypeError on z.ZodError (invalid schema)', async () => {
+      readFileSyncSpy.mockReturnValue('{"tld": "invalid", "routes": {}}');
+      await expect(import('../src/config')).rejects.toThrow(TypeError);
+      await expect(import('../src/config')).rejects.toThrow(
+        /^Invalid configuration:/,
+      );
+    });
+
+    it('should throw Error on generic error during file read', async () => {
+      readFileSyncSpy.mockImplementation(() => {
+        throw new Error('File not found');
+      });
+      await expect(import('../src/config')).rejects.toThrow(Error);
+      await expect(import('../src/config')).rejects.toThrow(
+        'Unexpected error while processing configuration file: File not found',
+      );
+    });
+
+    it('should throw Error on string thrown during file read', async () => {
+      readFileSyncSpy.mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw 'String error';
+      });
+      await expect(import('../src/config')).rejects.toThrow(Error);
+      await expect(import('../src/config')).rejects.toThrow(
+        'Unexpected error while processing configuration file: String error',
+      );
+    });
+  });
+
+  describe('environment variables parsing', () => {
+    it('should throw TypeError on z.ZodError (invalid schema)', async () => {
+      readFileSyncSpy.mockReturnValue('{"tld": ".test", "routes": {}}');
+      process.env.LOG_LEVEL = 'invalid';
+      await expect(import('../src/config')).rejects.toThrow(TypeError);
+      await expect(import('../src/config')).rejects.toThrow(
+        /^Invalid environment variables:/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added tests for `src/config.ts` to cover error handling during configuration file and environment variable parsing.

📊 **Coverage:** Mocked `fs.readFileSync` to test invalid JSON (`SyntaxError`), schema validation failures (`z.ZodError`), and unhandled read errors.
✨ **Result:** Improved test coverage by verifying the correct typed exceptions are thrown in error scenarios.

Fixes missing error path test issue.

---
*PR created automatically by Jules for task [2661341475311804270](https://jules.google.com/task/2661341475311804270) started by @jrobinsonc*